### PR TITLE
Fix behavior when no cleanup needed

### DIFF
--- a/src/PkgCleanup.jl
+++ b/src/PkgCleanup.jl
@@ -51,6 +51,7 @@ function cleanup(path::String, what::String;
     toml = TOML.parse(read(path, String))
     terminal = TTYTerminal("xterm", stdin, stdout, stderr)
     entries = sort!(collect(keys(toml)))
+    isempty(entries) && return nothing
     select_menu = MultiSelectMenu(entries)
     select_menu.selected = Set(collect(eachindex(entries)))
     choices = request(terminal, "Select the $(what) to keep in $(path)", select_menu)


### PR DESCRIPTION
When there are no entries, right now the following error occurs:

```julia
ERROR: MultiSelectMenu must have at least one option
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] REPL.TerminalMenus.MultiSelectMenu(options::Vector{String}; pagesize::Int64, selected::Vector{Int64}, warn::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ REPL.TerminalMenus ~/.julia/juliaup/julia-1.9.0-rc2+0.x64.linux.gnu/share/julia/stdlib/v1.9/REPL/src/TerminalMenus/MultiSelectMenu.jl:59
 [3] MultiSelectMenu
   @ ~/.julia/juliaup/julia-1.9.0-rc2+0.x64.linux.gnu/share/julia/stdlib/v1.9/REPL/src/TerminalMenus/MultiSelectMenu.jl:58 [inlined]
 [4] cleanup(path::String, what::String; stdin::Base.TTY, stdout::Base.TTY, stderr::Base.TTY)
   @ PkgCleanup ~/.julia/packages/PkgCleanup/TpJvG/src/PkgCleanup.jl:54
 [5] cleanup(path::String, what::String)
   @ PkgCleanup ~/.julia/packages/PkgCleanup/TpJvG/src/PkgCleanup.jl:46
 [6] artifacts
   @ ~/.julia/packages/PkgCleanup/TpJvG/src/PkgCleanup.jl:93 [inlined]
 [7] artifacts()
   @ PkgCleanup ~/.julia/packages/PkgCleanup/TpJvG/src/PkgCleanup.jl:93
 [8] top-level scope
   @ none:1
```